### PR TITLE
fixed issue with prompt instruction stacking

### DIFF
--- a/autogpts/autogpt/autogpt/agents/agent.py
+++ b/autogpts/autogpt/autogpt/agents/agent.py
@@ -108,10 +108,12 @@ class Agent(
     def build_prompt(
         self,
         *args,
-        extra_messages: list[ChatMessage] = [],
+        extra_messages: [list[ChatMessage]] = None,
         include_os_info: Optional[bool] = None,
         **kwargs,
     ) -> ChatPrompt:
+        if extra_messages is None: 
+            extra_messages = []
         # Clock
         extra_messages.append(
             ChatMessage.system(f"The current time and date is {time.strftime('%c')}"),


### PR DESCRIPTION

### Background

prompt instructions were stacking making the agent eventually return an error because the prompt was full of repeating instructions


### Changes 🏗️

made sure to reset extra_messages in build_prompt

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
